### PR TITLE
feat: agregar guía para selección de artefactos

### DIFF
--- a/docs/guias/GUI-04.md
+++ b/docs/guias/GUI-04.md
@@ -1,0 +1,80 @@
+---
+title: GUI-04-Guía de selección de artefactos en el WoW
+sidebar_label: GUI-04-Guía de selección de artefactos en el WoW
+slug: /gui-04-elegir-artefactos-wow
+---
+
+# GUI-04-Guía para la Selección de Artefactos en el WoW
+
+## Propósito
+Esta guía tiene como objetivo establecer criterios claros para seleccionar el artefacto adecuado dentro del WoW (políticas, procesos, estandares, guías y validaciones). Garantizando una mejor comprensión y evitar WoW zombies.
+
+
+## Procedimiento
+
+**1. Identificar la naturaleza del contenido**
+    Para seleccionar el artefacto correcto dentro del WoW, primero se tiene que determinar el propósito de la información que se desea crear:
+    | Artefacto | Descripción | Ejemplo |
+    | --------- | ----------- | ------- |
+    | Política | Regla general aplicable a todo el departamento y alineada con nuestra misión, visión y valores | "Todos los miembros del departamento son igual de valiosos" |
+    | Proceso | Es una secuencia estructurada de actividades necesarias para alcanzar un objetivo | "Proceso de desarrollo" |
+    | Estándar | Normativa que garantiza la uniformidad y calidad dentro del trabajo. Define cómo se debe hacer algo | "Estándar para documentos" |
+    | Guía | Explica el proceso, esta diseñado específicamente para las personas que no saben como ejecutar un proceso generalmente. | "Guía de instalación de Docusaurus" |
+    | Validación | Conjunto de criterios que se deben cumplir para asegurar la calidad | "Validación de requisitos antes de iniciar el desarrollo de una nueva funcionalidad." |
+
+**2. Aplicar los criterios de selección**
+  - Si el contenido define **reglas generales obligatorias**, registrar como una **política**.
+  - Si describe **cómo se estructura y ejecuta una serie de tareas**, registrar como un **proceso**.
+  - Si establece **criterios fijos para la calidad del trabajo**, debe ser un **estándar**.
+  - Si proporciona **recomendaciones o mejores prácticas**, se documenta como una **guía**.
+  - Si establece **requisitos mínimos obligatorios que deben verificarse antes de la aprobación**, se trata de una **validación**.
+
+**3. Documentar y almacenar el artefacto en el repositorio**
+  - Una vez seleccionado el tipo de artefacto, se tiene que utilizar la plantilla correspondiente para documentarlo.
+  - Almacenar el artefacto en el repositorio oficial del departamento (Wiki).
+  - Revisar periódicamente la validez del artefacto y actualízarlo si es necesario.
+
+## Escenario: Un restaurante
+  Para entender mejor la diferencia, se realizó una analogía con un restaurante:
+
+**1. Política** → "Todas las hamburguesas deben prepararse con ingredientes frescos."
+   - Es una regla general que debe cumplirse siempre.
+
+**2. Proceso** → "Cómo preparar una hamburguesa."
+   - Explica los pasos específicos para transformar los ingredientes en una hamburguesa:
+      1. Tomar los ingredientes: Pan, carne, queso, etc.
+      2. Cocinar la carne a fuego medio hasta que esté bien hecha.
+      3. Tostar el pan en la parrilla.
+      4. Armar la hamburguesa: Poner la carne sobre el pan, agregar queso, vegetales y salsas.
+      5. Servir en un plato.
+   - **Entrada**: Ingredientes crudos.
+   - **Salida**: Hamburguesa lista para servir.
+
+
+  **3. Estándar** → "Todas las hamburguesas deben tener 150g de carne y servirse con pan tostado."
+    - Define los criterios fijos de calidad.
+ 
+  **4. Guía** → "Cómo hacer una hamburguesa deliciosa."
+  - Explica consejos opcionales para mejorar la calidad del producto:
+      - "Usar carne de res con 80% magro y 20% grasa para mejor sabor."
+      - "Dejar reposar la carne 5 minutos después de cocinarla."
+      - "Evitar presionar la carne en la parrilla para mantener los jugos."
+
+  **5. Validación** → "Antes de servir, verificar que la hamburguesa tenga todos los ingredientes y una buena presentación."
+    - Se asegura de que la hamburguesa cumple con el estándar antes de entregarla.
+
+  ### Conclusión
+    - **El proceso** convierte los ingredientes en una hamburguesa con pasos definidos.
+    - **La guía** da consejos opcionales para hacer la hamburguesa mejor.
+    - **El estándar** define requisitos fijos para todas las hamburguesas.
+    - **La validación** revisa que la hamburguesa esté lista para servir.
+
+  > **💡 Tip:** No todos los procesos se aplican para todo el departamento, existen procesos que son únicos para cada proyecto. 
+
+
+## Control de cambios
+
+| Versión | Cambios realizados                               | Autor            | Fecha      |
+| -------- | ---------------------------------------------- | ---------------- | ---------- |
+| 1.0.0    | Creación de la guía para la selección de artefactos en el WoW | Benjamín Arauz & Carlos Galicia| 27/02/2025 |
+

--- a/docs/guias/GUI-04.md
+++ b/docs/guias/GUI-04.md
@@ -7,74 +7,76 @@ slug: /gui-04-elegir-artefactos-wow
 # GUI-04-Guía para la Selección de Artefactos en el WoW
 
 ## Propósito
-Esta guía tiene como objetivo establecer criterios claros para seleccionar el artefacto adecuado dentro del WoW (políticas, procesos, estandares, guías y validaciones). Garantizando una mejor comprensión y evitar WoW zombies.
 
+Esta guía tiene como objetivo establecer criterios claros para seleccionar el artefacto adecuado dentro del WoW (políticas, procesos, estándares, guías y validaciones), garantizar una mejor comprensión y evitar la generación de WoW zombies.
 
 ## Procedimiento
 
 **1. Identificar la naturaleza del contenido**
-    Para seleccionar el artefacto correcto dentro del WoW, primero se tiene que determinar el propósito de la información que se desea crear:
-    | Artefacto | Descripción | Ejemplo |
-    | --------- | ----------- | ------- |
-    | Política | Regla general aplicable a todo el departamento y alineada con nuestra misión, visión y valores | "Todos los miembros del departamento son igual de valiosos" |
-    | Proceso | Es una secuencia estructurada de actividades necesarias para alcanzar un objetivo | "Proceso de desarrollo" |
-    | Estándar | Normativa que garantiza la uniformidad y calidad dentro del trabajo. Define cómo se debe hacer algo | "Estándar para documentos" |
-    | Guía | Explica el proceso, esta diseñado específicamente para las personas que no saben como ejecutar un proceso generalmente. | "Guía de instalación de Docusaurus" |
-    | Validación | Conjunto de criterios que se deben cumplir para asegurar la calidad | "Validación de requisitos antes de iniciar el desarrollo de una nueva funcionalidad." |
+Para seleccionar el artefacto correcto dentro del WoW, primero se tiene que determinar el propósito de la información que se desea crear:
+| Artefacto | Descripción | Ejemplo |
+| --------- | ----------- | ------- |
+| **Política** | Regla general aplicable a un grupo de personas determinado al realizar una actividad específica. | "Políticas sobre reuniones departamentales". |
+| **Proceso** | Secuencia estructurada de actividades necesarias para alcanzar un objetivo. Cuenta con entradas y salidas tangibles y documentadas. | "Proceso para la creación de procesos". |
+| **Estándar** | Normativa que garantiza la uniformidad y calidad dentro del trabajo. Define las normas o reglas sobre cómo se debe hacer algo para cumplir con requisitos de calidad, seguridad, funcionalidad, etc. | "Estándar para documentos" |
+| **Guía** | Explica el procedimiento general para realizar una actividad. Está dirigida, en general, a personas que no saben cómo ejecutar un proceso o actividad. Se utiliza principalmente para fines didácticos (capacitación de miembros del equipo o departamento). Sus entradas y salidas suelen ser intangibles. **Entrada común:** Necesidad de adquirir conocimiento sobre un área de interés. **Salida común:** Conocimiento adquirido sobre el área de interés. | "Guía de instalación de Docusaurus" |
+| **Validación** | Conjunto de criterios deben cumplirse para asegurar la calidad. Instrumento final que evalúa si efectivamente se siguió el estándar definido del artefacto para aceptarlo o rechazarlo. | "Validación de documentos (de acuerdo con el estándar de documentos mencionado anteriormente)." |
 
 **2. Aplicar los criterios de selección**
-  - Si el contenido define **reglas generales obligatorias**, registrar como una **política**.
-  - Si describe **cómo se estructura y ejecuta una serie de tareas**, registrar como un **proceso**.
-  - Si establece **criterios fijos para la calidad del trabajo**, debe ser un **estándar**.
-  - Si proporciona **recomendaciones o mejores prácticas**, se documenta como una **guía**.
-  - Si establece **requisitos mínimos obligatorios que deben verificarse antes de la aprobación**, se trata de una **validación**.
+
+- Si el contenido define **reglas generales obligatorias de comportamiento o acción**, debe registrarse como una **política**.
+- Si describe **cómo se estructura y ejecuta una serie de tareas para generar un producto de trabajo a partir de otros**, debe registrarse como un **proceso**.
+- Si establece **criterios fijos para la calidad de un producto de trabajo**, debe registrarse como un **estándar**.
+- Si proporciona **recomendaciones, mejores prácticas o conocimiento valioso para realizar una actividad**, debe documentarse como una **guía**.
+- Si es **un instrumento de evaluación que verifica si se cumplen los requisitos establecidos en un estándar antes de su aprobación**, se trata de una **validación**.
 
 **3. Documentar y almacenar el artefacto en el repositorio**
-  - Una vez seleccionado el tipo de artefacto, se tiene que utilizar la plantilla correspondiente para documentarlo.
-  - Almacenar el artefacto en el repositorio oficial del departamento (Wiki).
-  - Revisar periódicamente la validez del artefacto y actualízarlo si es necesario.
+
+- Una vez seleccionado el tipo de artefacto, se debe utilizar la plantilla correspondiente para documentarlo.
+- El artefacto debe almacenarse en el repositorio oficial del departamento (Wiki).
+- Es importante revisar periódicamente la validez del artefacto y actualizarlo si es necesario.
 
 ## Escenario: Un restaurante
-  Para entender mejor la diferencia, se realizó una analogía con un restaurante:
 
-**1. Política** → "Todas las hamburguesas deben prepararse con ingredientes frescos."
-   - Es una regla general que debe cumplirse siempre.
+Para entender mejor la diferencia entre los artefactos, se presenta la siguiente analogía con un restaurante:
+
+**1. Política** → "El personal de cocina se debe de lavar las manos antes y después de la jornada de trabajo."
+
+- Es una regla general que aplica a un grupo de personas y debe cumplirse dentro del restaurante.
 
 **2. Proceso** → "Cómo preparar una hamburguesa."
-   - Explica los pasos específicos para transformar los ingredientes en una hamburguesa:
-      1. Tomar los ingredientes: Pan, carne, queso, etc.
-      2. Cocinar la carne a fuego medio hasta que esté bien hecha.
-      3. Tostar el pan en la parrilla.
-      4. Armar la hamburguesa: Poner la carne sobre el pan, agregar queso, vegetales y salsas.
-      5. Servir en un plato.
-   - **Entrada**: Ingredientes crudos.
-   - **Salida**: Hamburguesa lista para servir.
 
+- Explica los pasos específicos para transformar los ingredientes en una hamburguesa:
+  1. Tomar los ingredientes: pan, carne, queso, etc.
+  2. Cocinar la carne a fuego medio hasta que esté bien hecha.
+  3. Tostar el pan en la parrilla.
+  4. Armar la hamburguesa: Colocar la carne sobre el pan, agregar queso, vegetales y salsas.
+  5. Servir en un plato.
+- **Entrada**: Ingredientes crudos _(tangibles)_.
+- **Salida**: Hamburguesa lista para servir _(tangible)_.
 
-  **3. Estándar** → "Todas las hamburguesas deben tener 150g de carne y servirse con pan tostado."
-    - Define los criterios fijos de calidad.
- 
-  **4. Guía** → "Cómo hacer una hamburguesa deliciosa."
-  - Explica consejos opcionales para mejorar la calidad del producto:
-      - "Usar carne de res con 80% magro y 20% grasa para mejor sabor."
-      - "Dejar reposar la carne 5 minutos después de cocinarla."
-      - "Evitar presionar la carne en la parrilla para mantener los jugos."
+**3. Estándar** → "Todas las hamburguesas deben tener 150g de carne y servirse con pan tostado." - Define los criterios fijos de calidad de la hamburguesa.
 
-  **5. Validación** → "Antes de servir, verificar que la hamburguesa tenga todos los ingredientes y una buena presentación."
-    - Se asegura de que la hamburguesa cumple con el estándar antes de entregarla.
+**4. Guía** → "Cómo hacer una hamburguesa deliciosa."
 
-  ### Conclusión
-    - **El proceso** convierte los ingredientes en una hamburguesa con pasos definidos.
-    - **La guía** da consejos opcionales para hacer la hamburguesa mejor.
-    - **El estándar** define requisitos fijos para todas las hamburguesas.
-    - **La validación** revisa que la hamburguesa esté lista para servir.
+- Explica consejos al personal de cocina para mejorar la calidad del producto:
+  - "Se recomienda usar carne de res con 80% de magro y 20% de grasa para mejor sabor."
+  - "Es aconsejable dejar reposar la carne 5 minutos después de cocinarla."
+  - "Evitar presionar la carne en la parrilla para mantener los jugos."
 
-  > **💡 Tip:** No todos los procesos se aplican para todo el departamento, existen procesos que son únicos para cada proyecto. 
+**5. Validación** → "Antes de servir, verificar que la hamburguesa tenga 150g de carne y se haya servido con pan tostado (de acuerdo con el estándar de las hamburguesas). " - Se asegura de que la hamburguesa cumpla con el estándar antes de entregarla. Si no cumple con los requisitos, se rechaza la hamburguesa y no se sirve.
 
+### Conclusión
+
+    - **El proceso** transforma los ingredientes en una hamburguesa con pasos definidos.
+    - **La guía** proporciona recomendaciones y conocimientos opcionales para mejorar la hamburguesa.
+    - **El estándar** establece requisitos fijos que todas las hamburguesas deben cumplir.
+    - **La validación** evalúa si la hamburguesa cumple con el estándar antes de servirse.
+
+> **💡 Tip sobre la creación de procesos:** No todos los procesos son aplicables para todo el departamento, algunos son específicos de cada proyecto. Se recomienda probar el funcionamiento del proceso dentro del proyecto antes de proponerlo al departamento.
 
 ## Control de cambios
 
-| Versión | Cambios realizados                               | Autor            | Fecha      |
-| -------- | ---------------------------------------------- | ---------------- | ---------- |
-| 1.0.0    | Creación de la guía para la selección de artefactos en el WoW | Benjamín Arauz & Carlos Galicia| 27/02/2025 |
-
+| Versión | Cambios realizados                                            | Autor                           | Fecha      |
+| ------- | ------------------------------------------------------------- | ------------------------------- | ---------- |
+| 1.0.0   | Creación de la guía para la selección de artefactos en el WoW | Benjamín Arauz & Carlos Galicia | 27/02/2025 |

--- a/yarn.lock
+++ b/yarn.lock
@@ -6288,11 +6288,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 fstream@^1.0.12:
   version "1.0.12"
   resolved "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz"


### PR DESCRIPTION
# Guía para la selección de artefactos en el WoW

## Resumen
Esta guía tiene como objetivo establecer criterios claros para seleccionar el artefacto adecuado dentro del WoW (políticas, procesos, estándares, guías y validaciones), garantizar una mejor comprensión y evitar la generación de WoW zombies.

## ¿Dónde puedo previsualizar esta funcionalidad?
1. En la rama "docs/v1.0.0/GUI-04-guia-para-elegir-artefacto-adecuado-en-el-WoW".
2. Dirigirse a: docs -> guias -> GUI-04.md

## Tipos de cambios
<!--- ¿Qué tipos de cambios introduce tu código? Marca con una `x` las opciones que correspondan: -->
- [ ] Corrección de error (cambio que soluciona un problema sin afectar otras funcionalidades)
- [x] Nueva funcionalidad (cambio que agrega una nueva característica sin afectar otras funcionalidades)
- [ ] Cambio disruptivo (corrección o nueva funcionalidad que afecta el funcionamiento esperado)

## Lista de verificación:
<!--- Revisa todos los siguientes puntos y marca con una `x` los que apliquen. -->
- [x] Otro desarrollador ha revisado este PR y lo ha aprobado.
- [x] La rama será eliminada después de la aprobación.
